### PR TITLE
Update locator-assets.json

### DIFF
--- a/assets/locator-assets.json
+++ b/assets/locator-assets.json
@@ -85,5 +85,14 @@
         "Platform": "sharedassets3.assets",
         "MenuSound": "sharedassets2.assets",
         "ClearSound": "sharedassets31.assets"
+    },
+    "1.12.2": {
+        "Saber": "sharedassets23.assets",
+        "Note": "sharedassets2.assets",
+        "MenuTitle": "sharedassets32.assets",
+        "Trail": "sharedassets11.assets",
+        "Platform": "sharedassets3.assets",
+        "MenuSound": "sharedassets2.assets",
+        "ClearSound": "sharedassets32.assets"
     }
 }


### PR DESCRIPTION
A second `CubeNoteSmoothHD` is located in `sharedassets24.assets`
The second instance is not accompanied by any Arrow textures / mesh